### PR TITLE
Tests for increasing coverage of importAndOpenFiles@528-587@./org/jabref/cli/ArgumentProcessor.java 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -728,3 +728,5 @@ jmh {
     iterations = 10
     fork = 2
 }
+
+apply plugin: 'jacoco'

--- a/src/test/java/org/jabref/cli/ArgumentProcessorTest.java
+++ b/src/test/java/org/jabref/cli/ArgumentProcessorTest.java
@@ -34,6 +34,9 @@ import org.mockito.Answers;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
 
 class ArgumentProcessorTest {
 
@@ -62,6 +65,28 @@ class ArgumentProcessorTest {
         String outputBibFile = outputBib.toAbsolutePath().toString();
 
         List<String> args = List.of("--nogui", "--debug", "--aux", auxFile + "," + outputBibFile, originBib);
+
+        ArgumentProcessor processor = new ArgumentProcessor(
+                args.toArray(String[]::new),
+                Mode.INITIAL_START,
+                preferencesService,
+                mock(FileUpdateMonitor.class),
+                entryTypesManager);
+        processor.processArguments();
+
+        assertTrue(Files.exists(outputBib));
+    }
+    
+    @Test
+    void noFileImport(@TempDir Path tempDir) throws Exception {
+        String auxFile = Path.of(AuxCommandLineTest.class.getResource("paper.aux").toURI()).toAbsolutePath().toString();
+        String originBib = Path.of(AuxCommandLineTest.class.getResource("origin.bib").toURI()).toAbsolutePath().toString();
+        String noExistBib = "nonexistant.bib";
+
+        Path outputBib = tempDir.resolve("output.bisb").toAbsolutePath();
+        String outputBibFile = outputBib.toAbsolutePath().toString();
+
+        List<String> args = List.of("--nogui", "--debug", "--aux", auxFile + "," + outputBibFile, originBib, noExistBib);
 
         ArgumentProcessor processor = new ArgumentProcessor(
                 args.toArray(String[]::new),
@@ -103,7 +128,8 @@ class ArgumentProcessorTest {
         assertTrue(Files.exists(outputBib));
         BibEntryAssert.assertEquals(expectedEntries, outputBib, bibtexImporter);
     }
-
+    
+ 
     @Test
     void convertBibtexToTablerefsabsbib(@TempDir Path tempDir) throws Exception {
         Path originBib = Path.of(Objects.requireNonNull(ArgumentProcessorTest.class.getResource("origin.bib")).toURI());

--- a/src/test/java/org/jabref/cli/ArgumentProcessorTest.java
+++ b/src/test/java/org/jabref/cli/ArgumentProcessorTest.java
@@ -98,6 +98,28 @@ class ArgumentProcessorTest {
 
         assertTrue(Files.exists(outputBib));
     }
+    
+    @Test
+    void notBibImport(@TempDir Path tempDir) throws Exception {
+        String auxFile = Path.of(AuxCommandLineTest.class.getResource("paper.aux").toURI()).toAbsolutePath().toString();
+        String originBib = Path.of(AuxCommandLineTest.class.getResource("origin.bib").toURI()).toAbsolutePath().toString();
+        String notBib = "nonexistant";
+
+        Path outputBib = tempDir.resolve("output.bisb").toAbsolutePath();
+        String outputBibFile = outputBib.toAbsolutePath().toString();
+
+        List<String> args = List.of("--nogui", "--debug", "--aux", auxFile + "," + outputBibFile, originBib, notBib);
+
+        ArgumentProcessor processor = new ArgumentProcessor(
+                args.toArray(String[]::new),
+                Mode.INITIAL_START,
+                preferencesService,
+                mock(FileUpdateMonitor.class),
+                entryTypesManager);
+        processor.processArguments();
+
+        assertTrue(Files.exists(outputBib));
+    }
 
     @Test
     void exportMatches(@TempDir Path tempDir) throws Exception {


### PR DESCRIPTION
<!-- 
Added tests to see that program still produces output when one of the inputs does not end with bib or does not exist as a file
-->

