### PR TITLE
refactor: parseField method from CCN 19 to CCN 5, fixes #35

### DIFF
--- a/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
@@ -85,7 +85,8 @@ class LayoutHelperTest {
         LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences, abbreviationRepository);
         Layout layout = layoutHelper.getLayoutFromText();
         assertNotNull(layout);
-
+    }
+    @Test
     public void testBracketedOptionFieldParsing() throws Exception {
         StringReader stringReader = new StringReader("\\format[doi] DOI: \\doi");
         LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences, abbreviationRepository);


### PR DESCRIPTION
Split up parseField method into six methods. These methods help decompose the logic of the parseField() method into smaller, more manageable units, improving readability and maintainability.

As we can see down below the of the newly created methods the highest CC is 9 which shows **reduction of 50%**. The parseField method itself got CC 5

**When using lizard:**

Before:
        CCN
84     19    614      0     111 LayoutHelper::parseField@288-398@LayoutHelper.java

After refactoring:
        CCN
17      5        86      0      19 LayoutHelper::parseField@288-306@LayoutHelper.java
8        3        46      1       9 LayoutHelper::handleNonLetterCharacter@308-316@LayoutHelper.java
7        2        39      2       7 LayoutHelper::handleLetterCharacter@318-324@LayoutHelper.java
12      3      102      0      12 LayoutHelper::handleEmptyName@326-337@LayoutHelper.java
22      9      208      1      23 LayoutHelper::handleNonEmptyName@339-361@LayoutHelper.java
8        2        36      0       8 LayoutHelper::handleFormat@363-370@LayoutHelper.java