### PR TITLE
refactor: parseField method from CCN 19 to CCN 1, highest CCN of the methods is 10, fixes #35

### DIFF
--- a/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
@@ -85,7 +85,8 @@ class LayoutHelperTest {
         LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences, abbreviationRepository);
         Layout layout = layoutHelper.getLayoutFromText();
         assertNotNull(layout);
-
+    }
+    @Test
     public void testBracketedOptionFieldParsing() throws Exception {
         StringReader stringReader = new StringReader("\\format[doi] DOI: \\doi");
         LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences, abbreviationRepository);


### PR DESCRIPTION
Split up parseField method into five methods. These methods help decompose the logic of the parseField() method into smaller, more manageable units, improving readability and maintainability.

As we can see down below the of the newly created methods the highest CC is 10 which shows reduction of around 45%. The parseField method itself got CC 1.

When using lizard:

Before:
CCN
84 19 614 0 111 LayoutHelper::parseField@288-398@LayoutHelper.java

After:
        CCN
4         1     19      0       4 LayoutHelper::parseField@288-291@LayoutHelper.java
21       5    121      0      21 LayoutHelper::readFieldName@293-313@LayoutHelper.java
34     10    169      1      35 LayoutHelper::processFieldName@315-349@LayoutHelper.java
8         2     36      0       8 LayoutHelper::handleFormatField@351-358@LayoutHelper.java
10       2    100      0      10 LayoutHelper::handleEmptyFieldNameError@360-369@LayoutHelper.java
